### PR TITLE
fix "one-liner" link

### DIFF
--- a/docs/get-started/install-tea.md
+++ b/docs/get-started/install-tea.md
@@ -41,7 +41,7 @@ for your projects. They can use the power of tea to try out your project
 without installing tea or your project.
 
 {% hint style="success" %}
-See [The `tea` One-Liner](/using-tea/the-tea-one-liner.md) for more details
+See [The `tea` One-Liner](/docs/using-tea/the-tea-one-liner.md) for more details
 {% endhint %}
 
 


### PR DESCRIPTION
Currently broken on: https://docs.tea.xyz/getting-started/install-tea